### PR TITLE
Add a timeout method applying to the whole session

### DIFF
--- a/SSH2.xs
+++ b/SSH2.xs
@@ -574,6 +574,22 @@ CODE:
 
 #endif
 
+#if LIBSSH2_VERSION_NUM >= 0x010209
+
+void
+net_ss_timeout(SSH2* ss, long timeout)
+CODE:
+    libssh2_session_set_timeout(ss->session, timeout);
+
+#else
+
+void
+net_ss_timeout(SSH2* ss, long timeout)
+CODE:
+    croak("libssh2 version 1.2.9 or higher required for set_timeout support");
+
+#endif
+
 void
 net_ss_blocking(SSH2* ss, SV* blocking)
 CODE:

--- a/lib/Net/SSH2.pm
+++ b/lib/Net/SSH2.pm
@@ -665,6 +665,12 @@ Calls libssh2_trace with supplied bitmask, to enable all tracing use:
 
 You need a debug build of libssh2 with tracing support.
 
+=head2 timeout ( timeout_ms )
+
+Enables a global timeout (in milliseconds) which will affect every action.
+
+libssh2 version 1.2.9 or higher is required to use this method.
+
 =head2 method ( type [, values... ] )
 
 Sets or returns a method preference; for get, pass in the type only; to set,


### PR DESCRIPTION
Provides a solution for the issue #83115 on the rt.cpan.org tracker (https://rt.cpan.org/Public/Bug/Display.html?id=83115).

> Dear all,
> 
> Having a way to set a global timeout allows to avoid long freezes when
> network errors occur.
> 
> If I unplug the network cable after being connected and then try to open()
> a file through SFTP, Net::SSH2 takes about 15 minutes to detect there is a
> problem and returns.
> 
> libssh2 (version 1.2.9) provides libssh2_session_set_timeout() which allows
> to set a timeout that will affect every action on the session.
> 
> Best,
> 
> Thierry Treyer
