### PR TITLE
return the number of bytes recive. for SCP acknowledgement.

### DIFF
--- a/lib/Net/SSH2.pm
+++ b/lib/Net/SSH2.pm
@@ -425,7 +425,7 @@ sub scp_put {
     $chan->write("\0");
     my $eof;
     $chan->read($eof, 1);
-    return 1;
+    return $eof;
 }
 
 my %Event;


### PR DESCRIPTION
Hi,

this patch will return the number of bytes (0 or 1) of the SCP acknowledge. This is needed to detect errors if "scp" isn't installed on the remote side. (like for rhel/centos minimal installations)

Cheers,

Jan
