### PR TITLE
Allow passing undef for public key on `auth_publickey` method

### DIFF
--- a/SSH2.xs
+++ b/SSH2.xs
@@ -1224,7 +1224,7 @@ CODE:
 #endif
 
 void
-net_ss_auth_publickey(SSH2* ss, SV* username, const char* publickey, \
+net_ss_auth_publickey(SSH2* ss, SV* username, SV* publickey, \
  const char* privatekey, SV* passphrase = NULL)
 PREINIT:
     const char* pv_username;
@@ -1232,8 +1232,9 @@ PREINIT:
 CODE:
     clear_error(ss);
     pv_username = SvPV(username, len_username);
+
     XSRETURN_IV(!libssh2_userauth_publickey_fromfile_ex(ss->session,
-     pv_username, len_username, publickey, privatekey,
+     pv_username, len_username, default_string(publickey), privatekey,
      default_string(passphrase)));
 
 void


### PR DESCRIPTION
> http://www.libssh2.org/libssh2_userauth_publickey_fromfile_ex.html
> publickey - Path name of the public key file. (e.g. /etc/ssh/hostkey.pub).
>             If libssh2 is built against OpenSSL, this option can be set to NULL.

It would be good if user can set `publickey` as `NULL` for `libssh2_userauth_publickey_fromfile_ex`.

Please let me know if it needs further change to be qualified PR.