### PR TITLE
Use IO::Socket::IP for IPv6 support

### DIFF
--- a/lib/Net/SSH2.pm
+++ b/lib/Net/SSH2.pm
@@ -246,8 +246,8 @@ sub connect {
     $opts{Timeout} ||= 30;
 
     if (@_ == 2) {
-        require IO::Socket::INET;
-        $sock = IO::Socket::INET->new(
+        require IO::Socket::IP;
+        $sock = IO::Socket::IP->new(
             PeerHost => $_[0],
             PeerPort => $_[1],
             Timeout => $opts{Timeout},
@@ -663,7 +663,7 @@ returns (code, error name, error string).
 
 =head2 sock
 
-Returns a reference to the underlying L<IO::Socket::INET> object, or C<undef> if
+Returns a reference to the underlying L<IO::Socket::IP> object, or C<undef> if
 not yet connected.
 
 =head2 trace

--- a/t/Net-SSH2.t
+++ b/t/Net-SSH2.t
@@ -60,7 +60,8 @@ unless ($host) {
     print <<TEST;
 
 To test the connection capabilities of Net::SSH2, we need a test site running
-a secure shell server daemon.  Enter 'localhost' to use this host.
+a secure shell server daemon.  Enter 'localhost' or '127.0.0.1' to use this
+host over IPv4. Enter '::1' to use this host over IPv6.
 
 TEST
     print "Select host [ENTER to skip]: ";
@@ -71,7 +72,7 @@ SKIP: { # SKIP-server
 skip '- no server daemon available', 62 unless $host;
 ok($ssh2->connect($host), "connect to $host");
 
-isa_ok($ssh2->sock, 'IO::Socket::INET', '->sock isa IO::Socket::INET');
+isa_ok($ssh2->sock, 'IO::Socket::IP', '->sock isa IO::Socket::IP');
 
 # (8) server methods
 for my $type(qw(kex hostkey crypt_cs crypt_sc mac_cs mac_sc comp_cs comp_sc)) {


### PR DESCRIPTION
This is a patch to add IPv6 support by simply using IO::Socket::IP instead of IO::Socket::INET. Tested on  OS X with perl 5.16.3 and 5.8.9, and on Linux (Debian) with perl 5.20.2.