### PR TITLE
add cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,10 @@
+requires "Cwd";
+requires "File::Copy";
+requires "File::Spec";
+
+on 'develop' => sub {
+	requires "Module::Install";
+	requires "Module::Install::CheckLib";
+
+	requires "Test::Spelling";
+};


### PR DESCRIPTION
Hey
Module::Install is always an arse to use, as developer, because we never know what are the M::I modules that are required.
In order to help in that process, I added a cpanfile.

I did not add it to the distro, as I do not think it is relevant in that case.

hope it helps
alberto