### PR TITLE
Fix authentication method name for auth via ssh-agent (closes: #35)

### DIFF
--- a/lib/Net/SSH2.pm
+++ b/lib/Net/SSH2.pm
@@ -157,7 +157,7 @@ sub connect {
 sub _auth_methods {
     return {
         'agent' => {
-            ssh => 'agent',
+            ssh => 'publickey',
             method => \&auth_agent,
             params => [qw(_fallback username)],
         },


### PR DESCRIPTION
SSH auth name for auth_agent method should be 'publickey'
to meet server's authentication methods returned by auth_list(). 