### PR TITLE
ensure the crypto libraries are positioned after libssh2

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -258,6 +258,8 @@ EOF
     }
 }
 
+makemaker_append_once LIBS => '-lssh2', '-lz';
+
 if ($crypto_backend eq 'gcrypt') {
     makemaker_append_once(LDDLFLAGS => '-lgcrypt');
 }
@@ -282,8 +284,6 @@ makemaker_append_once(CCFLAGS => '-DPERL_GCC_PEDANTIC -std=c99 -pedantic-errors 
     if $Module::Install::AUTHOR and $linux and $cc_gcc;
 
 resources repository => 'git://github.com/rkitover/net-ssh2.git';
-
-makemaker_append_once LIBS => '-lssh2', '-lz';
 
 my $gen = "util/gen_constants.pl";
 if (-f $gen) {


### PR DESCRIPTION
This address the following missing symbol issue issue when using OpenSSL static libraries.

```
Can't load '/usr/local/perl/vendor/lib/freebsd/auto/Net/SSH2/SSH2.so' for module Net::SSH2: /usr/local/perl/vendor/lib/freebsd/auto/Net/SSH2/SSH2.so: Undefined symbol "EVP_des_ede3_cbc" at /usr/local/perl/lib/XSLoader.pm line 68.
 at /usr/local/perl/vendor/lib/freebsd/Net/SSH2.pm line 642.
Compilation failed in require at -e line 1.
BEGIN failed--compilation aborted at -e line 1.
```