### PR TITLE
Fixed $sftp->stat($file)

### DIFF
--- a/SSH2.xs
+++ b/SSH2.xs
@@ -2204,7 +2204,7 @@ PREINIT:
     LIBSSH2_SFTP_ATTRIBUTES attrs;
 PPCODE:
     pv_path = SvPVbyte(path, len_path);
-    error = !libssh2_sftp_stat_ex(sf->sftp, (char*)pv_path, len_path,
+    error = libssh2_sftp_stat_ex(sf->sftp, (char*)pv_path, len_path,
                                   (follow ? LIBSSH2_SFTP_STAT : LIBSSH2_SFTP_LSTAT),
                                   &attrs);
     if (error < 0)


### PR DESCRIPTION
libssh2_sftp_stat_ex returns an error code (or 0 on success). Hence, the return value must not be negated.

Note that the current code worked surprisingly often, because a negated success value was 1, and therefore considered success as well. However, when stat'ing a file that does not exist, the return value of $sftp->stat($file) was pretty random, since attrs was not initialized.