### PR TITLE
remove extra test for deadline

### DIFF
--- a/lib/Net/SSH2/Channel.pm
+++ b/lib/Net/SSH2/Channel.pm
@@ -89,7 +89,6 @@ sub read2 {
                 $ssh2->_set_error(Net::SSH2::LIBSSH2_ERROR_TIMEOUT(), "Time out waiting for data");
                 return;
             }
-            return if $deadline and time > $deadline;
             my $sock = $ssh2->sock;
             my $fn = fileno($sock);
             my ($rbm, $wbm) = ('', '');


### PR DESCRIPTION
This line follows the same test four lines above.

At best, this line does nothing, since it is only tested if the previous
test failed, so this test will almost always fail too.

At worst, the timing will be exactly right for the first test to fail
and the second test to pass, which would result in a return without
setting the "Time out" error.