### PR TITLE
Fix spelling error in manpage for Net::SSH2

### DIFF
--- a/lib/Net/SSH2.pm
+++ b/lib/Net/SSH2.pm
@@ -1488,7 +1488,7 @@ used to convert keys.
 
 Another common issue is that in the last years OpenSSH has
 incorporated several new cyphers that are not supported by any version
-of C<libssh2> yet (though the incomming 1.8.1 may aliviate the
+of C<libssh2> yet (though the incoming 1.8.1 may aliviate the
 situation). Currently the best option from an interoperability
 standpoint is probably to stick to RSA key usage.
 


### PR DESCRIPTION

Hi,

In Debian we are currently applying the following patch to Net-SSH2.
We thought you might be interested in it too.

    Description: Fix spelling error in manpage for Net::SSH2
    Origin: vendor
    Author: Salvatore Bonaccorso <carnil@debian.org>
    Last-Update: 2019-07-06
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libnet-ssh2-perl/raw/master/debian/patches/spelling-error-in-manpage.patch

I initially reported it at https://rt.cpan.org/Ticket/Display.html?id=129995
which can be closed, as the issue tracker seems to be used directly on github.

Thanks for considering,
  Salvatore Bonaccorso,
  Debian Perl Group
