### PR TITLE
Move bugs queue to github issues.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -282,6 +282,8 @@ makemaker_append_once(CCFLAGS => '-DPERL_GCC_PEDANTIC -std=c99 -pedantic-errors 
 
 resources repository => 'git://github.com/rkitover/net-ssh2.git';
 
+resources bugtracker => 'https://github.com/rkitover/net-ssh2/issues';
+
 my $gen = "util/gen_constants.pl";
 if (-f $gen) {
     system $^X, $gen


### PR DESCRIPTION
Set the bugtracker resource to github issues to replace the default RT.

People would still be able to use RT, but things like the Issues link on
metacpan.org would point to github issues instead.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>

@salva only if you agree with this.